### PR TITLE
More pragmatic resource-jsonld equality

### DIFF
--- a/src/JsonLdResourceNode.php
+++ b/src/JsonLdResourceNode.php
@@ -48,7 +48,7 @@ class JsonLdResourceNode extends ResourceNode {
 	 */
 	public function equals($target) {
 		return $target instanceof self &&
-			count(array_intersect($this->getUris(), $target->getUris())) > 0;
+			(count(array_intersect($this->getUris(), $target->getUris())) > 0 || $this->graph == $target->graph);
 	}
 
 	private function getUris() {

--- a/tests/phpunit/JsonLdResourceNodeTest.php
+++ b/tests/phpunit/JsonLdResourceNodeTest.php
@@ -58,6 +58,10 @@ class JsonLdResourceNodeTest extends \PHPUnit_Framework_TestCase {
 				new JsonLdResourceNode('Douglas Adams', (object) array('@context' => 'http://schema.org', 'sameAs' => array('foo', 'bar'))),
 				new JsonLdResourceNode('Douglas Adams', (object) array('@context' => 'http://schema.org', '@id' => 'foo'))
 			),
+			array(
+				new JsonLdResourceNode('Douglas Adams', (object) array('@context' => 'http://schema.org', 'name' => 'bar')),
+				new JsonLdResourceNode('Douglas Adams', (object) array('@context' => 'http://schema.org', 'name' => 'bar'))
+			)
 		);
 	}
 
@@ -75,13 +79,13 @@ class JsonLdResourceNodeTest extends \PHPUnit_Framework_TestCase {
 				new MissingNode()
 			),
 			array(
-				new JsonLdResourceNode('Douglas Adams', (object) array('http://schema.org/name' => 'Douglas Adams')),
-				new JsonLdResourceNode('Douglas Adams', (object) array('http://schema.org/name' => 'Douglas Adams'))
-			),
-			array(
 				new JsonLdResourceNode('Douglas Adams', (object) array('@context' => 'http://schema.org', '@id' => 'foo')),
 				new JsonLdResourceNode('Douglas Adams', (object) array('@context' => 'http://schema.org', '@id' => 'bar'))
 			),
+			array(
+				new JsonLdResourceNode('Douglas Adams', (object) array('@context' => 'http://schema.org', 'name' => 'bar')),
+				new JsonLdResourceNode('Douglas Adams', (object) array('@context' => 'http://schema.org'))
+			)
 		);
 	}
 }


### PR DESCRIPTION
States that resources described by the same graph are equals (it may be theoretically false but the software and the user has no way to state such things).

Sorry for the change but after reflexion it is the behavior that makes more sense.